### PR TITLE
updated package.json field for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple burger menu for Svelte with CSS transformations and transitions.",
   "svelte": "src/index.ts",
   "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
   "main": "dist/index.mjs",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
I did notice one thing that wasn't setup properly. Let me know how this works, because if there is a problem, I think I know the solution. In /dist/index.d.ts, it isn't actually exporting any types, and only importing a svelte component. So I think the solution is to use /src/types/DefaultProps.ts and export all types from there. I do want to see first though if the types will be exported with this current change, since the current types are included in the svelte components. 